### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.ManualGameTime.props
+++ b/props/LiveSplit.ManualGameTime.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/props/LiveSplit.ManualGameTime.props
+++ b/props/LiveSplit.ManualGameTime.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.ManualGameTime/LiveSplit.ManualGameTime.csproj
+++ b/src/LiveSplit.ManualGameTime/LiveSplit.ManualGameTime.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeComponent.cs
+++ b/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeComponent.cs
@@ -30,7 +30,7 @@ public class ManualGameTimeComponent : LogicComponent
 
     private void State_OnUndoSplit(object sender, EventArgs e)
     {
-        var curIndex = CurrentState.CurrentSplitIndex;
+        int curIndex = CurrentState.CurrentSplitIndex;
         CurrentState.SetGameTime(curIndex > 0 ? CurrentState.Run[curIndex - 1].SplitTime.GameTime : TimeSpan.Zero);
     }
 

--- a/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeComponent.cs
+++ b/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeComponent.cs
@@ -1,85 +1,85 @@
-﻿using LiveSplit.ManualGameTime.UI.Components;
-using LiveSplit.Model;
-using System;
+﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.ManualGameTime.UI.Components;
+using LiveSplit.Model;
+
+namespace LiveSplit.UI.Components;
+
+public class ManualGameTimeComponent : LogicComponent
 {
-    public class ManualGameTimeComponent : LogicComponent
+    public ManualGameTimeSettings Settings { get; set; }
+
+    public GraphicsCache Cache { get; set; }
+    protected LiveSplitState CurrentState { get; set; }
+    public Form GameTimeForm { get; set; }
+    protected Point PreviousLocation { get; set; }
+
+    public override string ComponentName => "Manual Game Time";
+
+    public ManualGameTimeComponent(LiveSplitState state)
     {
-        public ManualGameTimeSettings Settings { get; set; }
+        Settings = new ManualGameTimeSettings();
+        GameTimeForm = new ShitSplitter(state, Settings);
+        state.OnStart += state_OnStart;
+        state.OnReset += state_OnReset;
+        state.OnUndoSplit += State_OnUndoSplit;
+        CurrentState = state;
+    }
 
-        public GraphicsCache Cache { get; set; }
-        protected LiveSplitState CurrentState { get; set; }
-        public Form GameTimeForm { get; set; }
-        protected Point PreviousLocation { get; set; } 
+    private void State_OnUndoSplit(object sender, EventArgs e)
+    {
+        var curIndex = CurrentState.CurrentSplitIndex;
+        CurrentState.SetGameTime(curIndex > 0 ? CurrentState.Run[curIndex - 1].SplitTime.GameTime : TimeSpan.Zero);
+    }
 
-        public override string ComponentName => "Manual Game Time";
+    void state_OnReset(object sender, TimerPhase e)
+    {
+        GameTimeForm.Close();
+        PreviousLocation = GameTimeForm.Location;
+    }
 
-        public ManualGameTimeComponent(LiveSplitState state)
-        {
-            Settings = new ManualGameTimeSettings();
-            GameTimeForm = new ShitSplitter(state, Settings);
-            state.OnStart += state_OnStart;
-            state.OnReset += state_OnReset;
-            state.OnUndoSplit += State_OnUndoSplit;
-            CurrentState = state;
-        }
+    void state_OnStart(object sender, EventArgs e)
+    {
+        GameTimeForm = new ShitSplitter(CurrentState, Settings);
+        CurrentState.Form.Invoke(new Action(() => GameTimeForm.Show(CurrentState.Form)));
+        if (!PreviousLocation.IsEmpty)
+            GameTimeForm.Location = PreviousLocation;
+        CurrentState.IsGameTimePaused = true;
+        CurrentState.SetGameTime(TimeSpan.Zero);
+    }
 
-        private void State_OnUndoSplit(object sender, EventArgs e)
-        {
-            var curIndex = CurrentState.CurrentSplitIndex;
-            CurrentState.SetGameTime(curIndex > 0 ? CurrentState.Run[curIndex - 1].SplitTime.GameTime : TimeSpan.Zero);
-        }
+    public override Control GetSettingsControl(LayoutMode mode)
+    {
+        return Settings;
+    }
 
-        void state_OnReset(object sender, TimerPhase e)
-        {
+    public override System.Xml.XmlNode GetSettings(System.Xml.XmlDocument document)
+    {
+        return Settings.GetSettings(document);
+    }
+
+    public override void SetSettings(System.Xml.XmlNode settings)
+    {
+        Settings.SetSettings(settings);
+    }
+
+    public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
+    {
+    }
+
+    public override void Dispose()
+    {
+        if (GameTimeForm != null && !GameTimeForm.IsDisposed)
             GameTimeForm.Close();
-            PreviousLocation = GameTimeForm.Location;
-        }
+        CurrentState.OnStart -= state_OnStart;
+        CurrentState.OnReset -= state_OnReset;
+        CurrentState.OnUndoSplit -= State_OnUndoSplit;
+    }
 
-        void state_OnStart(object sender, EventArgs e)
-        {
-            GameTimeForm = new ShitSplitter(CurrentState, Settings);
-            CurrentState.Form.Invoke(new Action(() => GameTimeForm.Show(CurrentState.Form)));
-            if (!PreviousLocation.IsEmpty)
-                GameTimeForm.Location = PreviousLocation;
-            CurrentState.IsGameTimePaused = true;
-            CurrentState.SetGameTime(TimeSpan.Zero);
-        }
-
-        public override Control GetSettingsControl(LayoutMode mode)
-        {
-            return Settings;
-        }
-
-        public override System.Xml.XmlNode GetSettings(System.Xml.XmlDocument document)
-        {
-            return Settings.GetSettings(document);
-        }
-
-        public override void SetSettings(System.Xml.XmlNode settings)
-        {
-            Settings.SetSettings(settings);
-        }
-
-        public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
-        {
-        }
-
-        public override void Dispose()
-        {
-            if (GameTimeForm != null && !GameTimeForm.IsDisposed)
-                GameTimeForm.Close();
-            CurrentState.OnStart -= state_OnStart;
-            CurrentState.OnReset -= state_OnReset;
-            CurrentState.OnUndoSplit -= State_OnUndoSplit;
-        }
-
-        public int GetSettingsHashCode()
-        {
-            return Settings.GetSettingsHashCode();
-        }
+    public int GetSettingsHashCode()
+    {
+        return Settings.GetSettingsHashCode();
     }
 }

--- a/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeComponent.cs
+++ b/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeComponent.cs
@@ -45,7 +45,10 @@ public class ManualGameTimeComponent : LogicComponent
         GameTimeForm = new ShitSplitter(CurrentState, Settings);
         CurrentState.Form.Invoke(new Action(() => GameTimeForm.Show(CurrentState.Form)));
         if (!PreviousLocation.IsEmpty)
+        {
             GameTimeForm.Location = PreviousLocation;
+        }
+
         CurrentState.IsGameTimePaused = true;
         CurrentState.SetGameTime(TimeSpan.Zero);
     }
@@ -72,7 +75,10 @@ public class ManualGameTimeComponent : LogicComponent
     public override void Dispose()
     {
         if (GameTimeForm != null && !GameTimeForm.IsDisposed)
+        {
             GameTimeForm.Close();
+        }
+
         CurrentState.OnStart -= state_OnStart;
         CurrentState.OnReset -= state_OnReset;
         CurrentState.OnUndoSplit -= State_OnUndoSplit;

--- a/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeComponent.cs
+++ b/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeComponent.cs
@@ -34,13 +34,13 @@ public class ManualGameTimeComponent : LogicComponent
         CurrentState.SetGameTime(curIndex > 0 ? CurrentState.Run[curIndex - 1].SplitTime.GameTime : TimeSpan.Zero);
     }
 
-    void state_OnReset(object sender, TimerPhase e)
+    private void state_OnReset(object sender, TimerPhase e)
     {
         GameTimeForm.Close();
         PreviousLocation = GameTimeForm.Location;
     }
 
-    void state_OnStart(object sender, EventArgs e)
+    private void state_OnStart(object sender, EventArgs e)
     {
         GameTimeForm = new ShitSplitter(CurrentState, Settings);
         CurrentState.Form.Invoke(new Action(() => GameTimeForm.Show(CurrentState.Form)));

--- a/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeFactory.cs
+++ b/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeFactory.cs
@@ -16,7 +16,10 @@ public class ManualGameTimeFactory : IComponentFactory
 
     public ComponentCategory Category => ComponentCategory.Control;
 
-    public IComponent Create(LiveSplitState state) => new ManualGameTimeComponent(state);
+    public IComponent Create(LiveSplitState state)
+    {
+        return new ManualGameTimeComponent(state);
+    }
 
     public string UpdateName => ComponentName;
 

--- a/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeFactory.cs
+++ b/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeFactory.cs
@@ -1,28 +1,28 @@
-﻿using LiveSplit.Delta;
+﻿using System;
+
+using LiveSplit.Delta;
 using LiveSplit.Model;
 using LiveSplit.UI.Components;
-using System;
 
 [assembly: ComponentFactory(typeof(ManualGameTimeFactory))]
 
-namespace LiveSplit.Delta
+namespace LiveSplit.Delta;
+
+public class ManualGameTimeFactory : IComponentFactory
 {
-    public class ManualGameTimeFactory : IComponentFactory
-    {
-        public string ComponentName => "Manual Game Time";
+    public string ComponentName => "Manual Game Time";
 
-        public string Description => "Allows manually entering segment times as game time.";
+    public string Description => "Allows manually entering segment times as game time.";
 
-        public ComponentCategory Category => ComponentCategory.Control;
+    public ComponentCategory Category => ComponentCategory.Control;
 
-        public IComponent Create(LiveSplitState state) => new ManualGameTimeComponent(state);
+    public IComponent Create(LiveSplitState state) => new ManualGameTimeComponent(state);
 
-        public string UpdateName => ComponentName;
+    public string UpdateName => ComponentName;
 
-        public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.ManualGameTime.xml";
+    public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.ManualGameTime.xml";
 
-        public string UpdateURL => "http://livesplit.org/update/";
+    public string UpdateURL => "http://livesplit.org/update/";
 
-        public Version Version => Version.Parse("1.8.29");
-    }
+    public Version Version => Version.Parse("1.8.29");
 }

--- a/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeSettings.cs
+++ b/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeSettings.cs
@@ -1,43 +1,42 @@
 ﻿using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public partial class ManualGameTimeSettings : UserControl
 {
-    public partial class ManualGameTimeSettings : UserControl
+    public bool UseSegmentTimes { get; set; }
+
+    public ManualGameTimeSettings()
     {
-        public bool UseSegmentTimes { get; set; }
+        InitializeComponent();
 
-        public ManualGameTimeSettings()
-        {
-            InitializeComponent();
+        UseSegmentTimes = true;
 
-            UseSegmentTimes = true;
+        rdoSegmentTimes.DataBindings.Add("Checked", this, "UseSegmentTimes", false, DataSourceUpdateMode.OnPropertyChanged);
+    }
 
-            rdoSegmentTimes.DataBindings.Add("Checked", this, "UseSegmentTimes", false, DataSourceUpdateMode.OnPropertyChanged);
-        }
+    public void SetSettings(XmlNode node)
+    {
+        var element = (XmlElement)node;
+        UseSegmentTimes = SettingsHelper.ParseBool(element["UseSegmentTimes"]);
+    }
 
-        public void SetSettings(XmlNode node)
-        {
-            var element = (XmlElement)node;
-            UseSegmentTimes = SettingsHelper.ParseBool(element["UseSegmentTimes"]);
-        }
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        var parent = document.CreateElement("Settings");
+        CreateSettingsNode(document, parent);
+        return parent;
+    }
 
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            var parent = document.CreateElement("Settings");
-            CreateSettingsNode(document, parent);
-            return parent;
-        }
+    public int GetSettingsHashCode()
+    {
+        return CreateSettingsNode(null, null);
+    }
 
-        public int GetSettingsHashCode()
-        {
-            return CreateSettingsNode(null, null);
-        }
-
-        private int CreateSettingsNode(XmlDocument document, XmlElement parent)
-        {
-            return SettingsHelper.CreateSetting(document, parent, "Version", "1.4") ^
-            SettingsHelper.CreateSetting(document, parent, "UseSegmentTimes", UseSegmentTimes);
-        }
+    private int CreateSettingsNode(XmlDocument document, XmlElement parent)
+    {
+        return SettingsHelper.CreateSetting(document, parent, "Version", "1.4") ^
+        SettingsHelper.CreateSetting(document, parent, "UseSegmentTimes", UseSegmentTimes);
     }
 }

--- a/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeSettings.cs
+++ b/src/LiveSplit.ManualGameTime/UI/Components/ManualGameTimeSettings.cs
@@ -24,7 +24,7 @@ public partial class ManualGameTimeSettings : UserControl
 
     public XmlNode GetSettings(XmlDocument document)
     {
-        var parent = document.CreateElement("Settings");
+        XmlElement parent = document.CreateElement("Settings");
         CreateSettingsNode(document, parent);
         return parent;
     }

--- a/src/LiveSplit.ManualGameTime/UI/Components/ShitSplitter.cs
+++ b/src/LiveSplit.ManualGameTime/UI/Components/ShitSplitter.cs
@@ -1,47 +1,47 @@
-﻿using LiveSplit.Model;
-using LiveSplit.UI.Components;
-using System;
+﻿using System;
 using System.Windows.Forms;
 
-namespace LiveSplit.ManualGameTime.UI.Components
+using LiveSplit.Model;
+using LiveSplit.UI.Components;
+
+namespace LiveSplit.ManualGameTime.UI.Components;
+
+public partial class ShitSplitter : Form
 {
-    public partial class ShitSplitter : Form
+    protected ITimerModel Model { get; set; }
+    protected ManualGameTimeSettings Settings { get; set; }
+
+    public ShitSplitter(LiveSplitState state, ManualGameTimeSettings settings)
     {
-        protected ITimerModel Model { get; set; }
-        protected ManualGameTimeSettings Settings { get; set; }
-
-        public ShitSplitter(LiveSplitState state, ManualGameTimeSettings settings)
+        InitializeComponent();
+        Model = new TimerModel()
         {
-            InitializeComponent();
-            Model = new TimerModel()
-            {
-                CurrentState = state
-            };
-            Settings = settings;
-        }
+            CurrentState = state
+        };
+        Settings = settings;
+    }
 
-        private void txtGameTime_KeyPress(object sender, KeyPressEventArgs e)
+    private void txtGameTime_KeyPress(object sender, KeyPressEventArgs e)
+    {
+        if (e.KeyChar == '\r')
         {
-            if (e.KeyChar == '\r')
+            try
             {
-                try
+                var timeSpans = txtGameTime.Text.Replace(" ", "").Split('+');
+                var totalTime = TimeSpan.Zero;
+                foreach (var time in timeSpans)
                 {
-                    var timeSpans = txtGameTime.Text.Replace(" ", "").Split('+');
-                    var totalTime = TimeSpan.Zero;
-                    foreach (var time in timeSpans)
-                    {
-                        totalTime += TimeSpanParser.Parse(time);
-                    }
-
-                    var newGameTime = totalTime + (Settings.UseSegmentTimes ? Model.CurrentState.CurrentTime.GameTime : TimeSpan.Zero);
-                    Model.CurrentState.SetGameTime(newGameTime);
-                    Model.Split();
-                    txtGameTime.Text = "";
+                    totalTime += TimeSpanParser.Parse(time);
                 }
-                catch { }
 
-                e.Handled = true;
+                var newGameTime = totalTime + (Settings.UseSegmentTimes ? Model.CurrentState.CurrentTime.GameTime : TimeSpan.Zero);
+                Model.CurrentState.SetGameTime(newGameTime);
+                Model.Split();
+                txtGameTime.Text = "";
             }
+            catch { }
+
+            e.Handled = true;
         }
     }
 }

--- a/src/LiveSplit.ManualGameTime/UI/Components/ShitSplitter.cs
+++ b/src/LiveSplit.ManualGameTime/UI/Components/ShitSplitter.cs
@@ -27,14 +27,14 @@ public partial class ShitSplitter : Form
         {
             try
             {
-                var timeSpans = txtGameTime.Text.Replace(" ", "").Split('+');
-                var totalTime = TimeSpan.Zero;
-                foreach (var time in timeSpans)
+                string[] timeSpans = txtGameTime.Text.Replace(" ", "").Split('+');
+                TimeSpan totalTime = TimeSpan.Zero;
+                foreach (string time in timeSpans)
                 {
                     totalTime += TimeSpanParser.Parse(time);
                 }
 
-                var newGameTime = totalTime + (Settings.UseSegmentTimes ? Model.CurrentState.CurrentTime.GameTime : TimeSpan.Zero);
+                TimeSpan? newGameTime = totalTime + (Settings.UseSegmentTimes ? Model.CurrentState.CurrentTime.GameTime : TimeSpan.Zero);
                 Model.CurrentState.SetGameTime(newGameTime);
                 Model.Split();
                 txtGameTime.Text = "";


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
